### PR TITLE
libcufft 12.1.0.78

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -170,7 +170,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/libcufft-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libcufft" %}
-{% set version = "12.0.0.61" %}
-{% set cuda_version = "13.0" %}
+{% set version = "12.1.0.31" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 5cdef1238c270f8f148da18587fdba8b9478c596e40f5490bba2b15c94915dd9  # [linux64]
-  sha256: 5361f3b22a50923204e07f7ff601150dc67aab6b0fff26c47bd3ac0a50c921a0  # [aarch64]
-  sha256: 4f2695ea50f895618316ee32636f5d0e5e0bc330e74b3e0876bff002af9e1eb3  # [win]
+  sha256: ae581630570d8446920145d12a560c0b85edd383340b4c56554bb63591b9b960  # [linux64]
+  sha256: 97b0957b446e8f2e1473a67864051967916794e8a21db8cb4d2c9dd7d06f17eb  # [aarch64]
+  sha256: db7d149c51be5c79a5f47a45b3b495e13ed8d5fe673f7cd9b5caf1bf19e22866  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libcufft" %}
-{% set version = "12.1.0.31" %}
+{% set version = "12.1.0.78" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: ae581630570d8446920145d12a560c0b85edd383340b4c56554bb63591b9b960  # [linux64]
-  sha256: 97b0957b446e8f2e1473a67864051967916794e8a21db8cb4d2c9dd7d06f17eb  # [aarch64]
-  sha256: db7d149c51be5c79a5f47a45b3b495e13ed8d5fe673f7cd9b5caf1bf19e22866  # [win]
+  sha256: 336732ded69b9f7f5cdca3e7e942732f1446933f2dccaf563c84b5caf058ad75  # [linux64]
+  sha256: 66302c6927af275515c5bd68275250f7c6e47521938c4d77318c7cba1f8715c6  # [aarch64]
+  sha256: b0a3df65c6ce60dc1aa695f47159a26d5172ac7411045abaeea2fbe948a42746  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
libcufft 12.1.0.78

**Destination channel:** defaults

### Links

- [PKG-12015](https://anaconda.atlassian.net/browse/PKG-12015) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12015]: https://anaconda.atlassian.net/browse/PKG-12015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ