### PR TITLE
libcufft v11.4.1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,10 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [linux and aarch64]
-  - tegra         # [linux and aarch64]
+#  - tegra         # [linux and aarch64]
 c_stdlib_version:  # [linux]
-  - 2.17           # [linux and aarch64]
-  - 2.34           # [linux and aarch64]
+  - "2.28"           # [linux and aarch64]
+#  - 2.34           # [linux and aarch64]
 zip_keys:               # [linux and aarch64]
   -                     # [linux and aarch64]
     - arm_variant_type  # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,9 @@ source:
   sha256: f26f80bb9abff3269c548e1559e8c2b4ba58ccb8acc6095bbc6404fc962d4b80  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -37,6 +37,14 @@ requirements:
 
 outputs:
   - name: libcufft
+    build:
+      binary_relocation: false
+      missing_dso_whitelist:
+        # Needed for the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'  # [linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libcufft*.so*'  # [linux and aarch64]
     files:
       - lib/libcufft*.so.*                            # [linux]
       - targets/{{ target_name }}/lib/libcufft*.so.*  # [linux]
@@ -74,10 +82,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: cuFFT native runtime libraries
       description: |
         The cuFFT library provides GPU-accelerated Fast Fourier Transform (FFT) implementations.
       doc_url: https://docs.nvidia.com/cuda/cufft/
+      dev_url: https://docs.nvidia.com/cuda/cufft/
 
   - name: libcufft-dev
     build:
@@ -129,10 +139,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: cuFFT native runtime libraries
       description: |
         The cuFFT library provides GPU-accelerated Fast Fourier Transform (FFT) implementations.
       doc_url: https://docs.nvidia.com/cuda/cufft/
+      dev_url: https://docs.nvidia.com/cuda/cufft/
 
   - name: libcufft-static
     # cuFFT does not ship `*_static.lib` on Windows so only relevant on linux
@@ -161,10 +173,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: cuFFT native runtime libraries
       description: |
         The cuFFT library provides GPU-accelerated Fast Fourier Transform (FFT) implementations.
       doc_url: https://docs.nvidia.com/cuda/cufft/
+      dev_url: https://docs.nvidia.com/cuda/cufft/
 
 
 about:
@@ -172,10 +186,12 @@ about:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_file: LICENSE
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: cuFFT native runtime libraries
   description: |
     The cuFFT library provides GPU-accelerated Fast Fourier Transform (FFT) implementations.
   doc_url: https://docs.nvidia.com/cuda/cufft/
+  dev_url: https://docs.nvidia.com/cuda/cufft/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libcufft 11.4.1.4

**Destination channel:** defaults

### Links

- [PKG-12781](https://anaconda.atlassian.net/browse/PKG-12781) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.

[PKG-12781]: https://anaconda.atlassian.net/browse/PKG-12781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ